### PR TITLE
fix: 修复 native quant 模型二次运行 meta tensor 报错

### DIFF
--- a/comfy_quant_linear.py
+++ b/comfy_quant_linear.py
@@ -479,6 +479,56 @@ def dequantize_comfy_quant_weight(weight, fmt, compute_dtype, scale=None, block_
     return _slice_logical_shape(weight, logical_shape)
 
 
+def _contains_meta_tensor(value):
+    if isinstance(value, torch.Tensor):
+        return value.device.type == "meta"
+    if isinstance(value, (tuple, list)):
+        return any(_contains_meta_tensor(item) for item in value)
+    if isinstance(value, dict):
+        return any(_contains_meta_tensor(item) for item in value.values())
+    if hasattr(value, "_asdict"):
+        return any(_contains_meta_tensor(item) for item in value._asdict().values())
+    if hasattr(value, "__dict__"):
+        return any(_contains_meta_tensor(item) for item in vars(value).values())
+    return False
+
+
+def has_comfy_quant_meta_weights(model, sd, prefix=""):
+    """Return True if native quant Linear weights need rebuilding from state_dict."""
+    if sd is None:
+        return False
+    if prefix == "":
+        _ensure_comfy_quant_backend()
+
+    for name, module in model.named_children():
+        child_prefix = (prefix + name + ".").replace("_orig_mod.", "")
+        if has_comfy_quant_meta_weights(module, sd, child_prefix):
+            return True
+
+        if not isinstance(module, nn.Linear):
+            continue
+        if "loras" in child_prefix or (child_prefix + "comfy_quant") not in sd:
+            continue
+
+        weight = getattr(module, "weight", None)
+        if not isinstance(weight, torch.Tensor):
+            return True
+        if weight.device.type == "meta":
+            return True
+        if not (hasattr(weight, "_qdata") and hasattr(weight, "_params")):
+            return True
+        if _contains_meta_tensor(getattr(weight, "_qdata", None)):
+            return True
+        if _contains_meta_tensor(getattr(weight, "_params", None)):
+            return True
+        if _contains_meta_tensor(getattr(module, "_comfy_quant_weight_scale", None)):
+            return True
+        if _contains_meta_tensor(getattr(module, "_comfy_quant_block_scale", None)):
+            return True
+
+    return False
+
+
 def replace_with_comfy_quant_linear(model, sd, compute_dtype, load_device, prefix=""):
     """Assign QuantizedTensor weights to matching Linear/CustomLinear modules."""
     if sd is None:

--- a/nodes_model_loading.py
+++ b/nodes_model_loading.py
@@ -20,7 +20,12 @@ from .wanvideo.modules.t5 import T5EncoderModel
 from .wanvideo.modules.clip import CLIPModel
 from .wanvideo.wan_video_vae import WanVideoVAE, WanVideoVAE38
 from .custom_linear import _replace_linear
-from .comfy_quant_linear import get_state_dict_weight_shape, is_comfy_quant_state_dict, replace_with_comfy_quant_linear
+from .comfy_quant_linear import (
+    get_state_dict_weight_shape,
+    has_comfy_quant_meta_weights,
+    is_comfy_quant_state_dict,
+    replace_with_comfy_quant_linear,
+)
 
 from accelerate import init_empty_weights
 from .utils import set_module_tensor_to_device, get_module_memory_mb_per_device
@@ -888,10 +893,15 @@ def load_weights(transformer, sd=None, weight_dtype=None, base_dtype=None,
             transformer.gguf_patched = True
     else:
         log.info("Loading and assigning model weights to device...")
-        if comfy_quant and not getattr(transformer, "comfy_quant_patched", False):
-            log.info("ComfyUI-native quantized checkpoint detected; reconstructing QuantizedTensor weights...")
-            replace_with_comfy_quant_linear(transformer, sd, base_dtype, transformer_load_device)
-            transformer.comfy_quant_patched = True
+        if comfy_quant:
+            needs_quant_rebuild = not getattr(transformer, "comfy_quant_patched", False)
+            if not needs_quant_rebuild:
+                needs_quant_rebuild = has_comfy_quant_meta_weights(transformer, sd)
+
+            if needs_quant_rebuild:
+                log.info("ComfyUI-native quantized checkpoint detected; reconstructing QuantizedTensor weights...")
+                replace_with_comfy_quant_linear(transformer, sd, base_dtype, transformer_load_device)
+                transformer.comfy_quant_patched = True
     named_params = transformer.named_parameters()
 
     for name, param in tqdm(named_params,


### PR DESCRIPTION
AI工具披露:
此PR使用Codex GPT-5.5-超高思考模式进行开发


## 背景

使用 ComfyUI native quantized checkpoint 时，工作流首次运行正常；但在开启 `force_offload` 后，修改 seed 再次运行会报错：

`Cannot copy out of meta tensor; no data!`

原因是首次采样结束后，量化权重被 offload 到 `meta`，第二次运行时模型已标记为 `comfy_quant_patched`，加载逻辑跳过了 `QuantizedTensor` 重建，导致 forward 阶段尝试从 `meta` tensor 拷贝数据。

## 修改内容

- 新增 native quant 权重状态检测，识别 `QuantizedTensor` 权重、量化参数或 scale buffer 是否处于 `meta`。
- 在模型加载阶段，如果发现已 patch 的 native quant 权重需要恢复，则重新从 `state_dict` 构建 `QuantizedTensor`。
- 保留首次加载只 patch 一次的逻辑，避免影响普通模型路径。

## 影响范围

该修复仅影响 ComfyUI native quantized checkpoint 的加载/重载路径。

普通 fp16、fp8、GGUF 等模型路径不受影响。

## 验证

- 同一工作流首次运行成功。
- 修改 seed 后再次运行成功，不再出现 `Cannot copy out of meta tensor; no data!`。
- 已通过语法检查和 `git diff --check`。