### PR TITLE
docs: clarify attribution scope

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -6,15 +6,18 @@ kijai/ComfyUI-WanVideoWrapper:
 https://github.com/kijai/ComfyUI-WanVideoWrapper
 
 The original ComfyUI-WanVideoWrapper project and its original portions remain
-copyrighted by kijai and its contributors. Deep thanks to kijai for the work
-that made this project possible.
+copyrighted by kijai and its contributors. Other upstream or third-party
+portions, including Alibaba Wan, ComfyUI, ComfyUI native quantization support,
+and bundled model/feature implementations, remain copyrighted by their
+respective authors. Deep thanks to those projects and contributors.
 
 This project is distributed under the Apache License, Version 2.0. See LICENSE.
 
-Modified portions and newly added code in this repository are Copyright (c)
-2026 wuwukasi/wuwukaka. Redistribution of this project, derivative works, or
-modifications that include or are based on these modified portions must retain
-this NOTICE and the copyright/modification notices in the relevant source files.
+Modified portions and newly added source expression by wuwukasi/wuwukaka in
+this repository are Copyright (c) 2026 wuwukasi/wuwukaka. Redistribution of this
+project, derivative works, or modifications that include or are based on these
+modified portions must retain this NOTICE and the copyright/modification notices
+in the relevant source files.
 
 Projects that use, copy, adapt, or modify the wuwukasi/wuwukaka portions must
 include a detailed modification notice in accompanying documentation, such as a
@@ -24,7 +27,7 @@ minimum:
 - Identify that the work includes code derived from ComfyUI-WanAnimatePlus by
   wuwukasi/wuwukaka.
 - Identify the affected modules, files, or feature areas derived from
-  wuwukasi/wuwukaka additions.
+  wuwukasi/wuwukaka additions/modifications.
 - Describe the downstream modifications made to those portions, if any.
 - Retain existing copyright headers and modification notices in modified source
   files, and add new prominent notices for downstream changes.
@@ -41,32 +44,56 @@ This attribution notice applies to the WanAnimatePlus-specific additions and
 does not modify the Apache License 2.0 terms for the upstream Apache-licensed
 portions.
 
-The wuwukasi/wuwukaka additions include, without limitation:
+The wuwukasi/wuwukaka additions/modifications include, without limitation:
 
-- WanAnimatePlus-specific node registration, node renaming, and integration
-  glue for added features.
+- WanAnimatePlus-specific node registration, node renaming, category isolation,
+  and integration glue for added workflow features.
 - Prefix frame conditioning, transition video conditioning, transition/outfit
-  layouts, canvas expansion trimming, and sampler-side continuation metadata.
-- Bernini in-context conditioning, context_latents/context_roles propagation,
-  Bernini source_id RoPE handling, context-window slicing, guidance modes, and
-  native-aspect reference preprocessing.
+  layouts, canvas expansion trimming, sampler-side continuation metadata, and
+  related context-window/loop integration.
+- Bernini node and sampler integration, including source/reference media
+  preprocessing, context_latents/context_roles metadata threading, local
+  context-window strategy changes, guidance-mode routing, native-aspect
+  reference preprocessing, and cache-key correctness fixes for the added
+  context paths.
 - SCAIL-2 embeds support, including wrapper-native ref/pose/mask conditioning,
-  prefix_mask pixel-frame replacement before mask latent encoding,
-  prefix/transition freeze handling, decode-side canvas trimming, and
-  context-window prepend/fusion integration.
-- EverAnimate embeds support, anchor selection and padding, pose/face/bg/mask
-  conditioning, ping-pong sequence handling, and related sampling safeguards.
-- Sampler/model changes for WanAnimatePlus context windows, prefix handling,
-  looping continuation, SCAIL-2 loop output tensor caching/background saves,
-  cache handling, graph-detach/inference tensor safeguards, T2V/Bernini fast
-  path optimizations, fast-path cache-key helpers, and main-path cross-attention
-  attention-mode propagation.
-- Custom linear operation registration safeguards and WanAnimatePlus-specific
-  custom op handling.
-- ComfyUI native quantized linear loading support for NVFP4/FP8 checkpoints,
-  adapted from PR #2029 in this fork's upstream/original project,
-  kijai/ComfyUI-WanVideoWrapper
-  (https://github.com/kijai/ComfyUI-WanVideoWrapper/pull/2029). Copyright in
-  the adapted upstream PR code remains with its author(s) and the upstream
-  ComfyUI-WanVideoWrapper contributors; WanAnimatePlus modifications include
-  package integration, loader safeguards, and CustomLinear dispatch adaptation.
+  single-frame prefix reference handling, legacy prefix-mask pixel-frame
+  handling, prefix/transition freeze handling, decode-side canvas trimming,
+  context-window prepend/fusion integration, loop tensor caching/background
+  saves, and subprocess-isolated color matching.
+- EverAnimate embeds and sampler support, including anchor selection and
+  padding, pose/face/bg/mask conditioning, ping-pong sequence handling, segment
+  sampling, and related safeguards.
+- Sampler/model safeguards and optimizations added for WanAnimatePlus paths,
+  including graph-detach/inference tensor safeguards, T2V/Bernini/SCAIL fast
+  paths, fast-path/cache helper logic, and attention-mode propagation.
+- Custom operation namespace changes, duplicate-registration safeguards, and
+  WanAnimatePlus-specific custom op handling.
+- CustomLinear MXFP8/block-wise scale_weight handling and related
+  WanAnimatePlus fallback/integration paths.
+
+Authorship scope exclusions:
+
+- Wan, WanVideo, ComfyUI-WanVideoWrapper, ComfyUI, model architecture code,
+  schedulers, attention implementations, and other upstream/third-party code are
+  not claimed as original wuwukasi/wuwukaka code merely because they are present
+  in this repository.
+- RoPE mathematics, ComfyUI/Comfy RoPE implementations, upstream Wan RoPE
+  helpers, and source-id / in-context RoPE mechanisms are not claimed as
+  original wuwukasi/wuwukaka code. WanAnimatePlus claims only the integration,
+  parameter threading, cache identity fixes, and local context-window strategy
+  changes actually added for its own Bernini/SCAIL/context paths.
+- ComfyUI native quantized linear loading combines WanAnimatePlus work that
+  predates PR #2029, including MXFP8/block-wise scale_weight support, with code
+  later imported or adapted from PR #2029 in this fork's upstream/original
+  project, kijai/ComfyUI-WanVideoWrapper
+  (https://github.com/kijai/ComfyUI-WanVideoWrapper/pull/2029), for ComfyUI
+  native-quant compatibility. Copyright in the adapted upstream PR code remains
+  with its author(s) and the upstream ComfyUI-WanVideoWrapper contributors.
+  WanAnimatePlus also substantially modified, completed, and hardened that
+  incomplete upstream PR implementation for this fork. WanAnimatePlus
+  modifications include the earlier MXFP8 path, package integration,
+  prefix/device/materialization fixes, loader safeguards, fallback/dequantization
+  paths, and CustomLinear dispatch/LoRA adaptation. WanAnimatePlus claims only
+  those modifications and newly written source expression, not the original
+  upstream PR code.

--- a/README.md
+++ b/README.md
@@ -175,10 +175,10 @@ Creates SCAIL-2 conditioning for WanAnimatePlus sampling. Use this node with SCA
 | `vae` | VAE model for encoding |
 | `width` / `height` / `num_frames` | Target dimensions; width and height are aligned to multiples of 32 |
 | `ref_image` | Reference image for SCAIL-2 conditioning |
-| `bg_image` | Optional single background image for animation mode; prepended as the first `prefix_frames` item with an internal white mask and ignored in replacement mode |
+| `bg_image` | Optional single background image for animation mode. In single-frame mode it is encoded as an extra background reference latent; in legacy canvas-prefix mode it is appended after user `prefix_frames`. Ignored in replacement mode |
 | `pose_images` | Driving pose video/images, encoded at half resolution |
 | `pose_image_mask` | Colored per-identity pose mask sequence |
-| `prefix_mask` | Optional colored mask images matching `prefix_frames`; expanded as `1+4+4...` and written into the prefix mask frames before mask latent encoding |
+| `prefix_mask` | Optional colored mask images matching `prefix_frames`; in single-frame mode it follows the reference-mask path, and in legacy canvas-prefix mode it is expanded as `1+4+4...` and written into prefix pixel mask frames |
 | `reference_image_mask` | Colored reference mask image |
 | `replacement_mode` | Enables SCAIL-2 replacement-mode RoPE and reference-mask compositing |
 | `preserve_main_ref_background` | Animation mode only; keeps the main reference image background when enabled, or uses `reference_image_mask` as a black-background alpha crop when disabled. Ignored in replacement mode |
@@ -192,7 +192,7 @@ For short generations, context windows are optional. For long generations or low
 
 For SCAIL-2, the default `single_frame_prefix_encoding` mode does not expand or trim the output for `prefix_frames`. If `transition_video` is connected, the front canvas expands by 21 pixel frames and those 21 frames are trimmed after decoding. With `single_frame_prefix_encoding` disabled, `prefix_frames` use the legacy 37 front pixel-frame canvas layout, with transition frames placed at frames 17-36 when `transition_video` is also connected.
 
-When `bg_image` is connected in animation mode, it consumes the first prefix slot and is handled as the first prefix image. The node internally adds a white mask for that background image only; user-provided `prefix_frames` and `prefix_mask` are then limited to four images each. In replacement mode, `bg_image` is ignored.
+When `bg_image` is connected in animation mode, the node internally adds a white mask for that background image. User-provided `prefix_frames` and `prefix_mask` are limited to four images each so the background can occupy the remaining reference/prefix capacity. In replacement mode, `bg_image` is ignored.
 
 ## Project Structure
 
@@ -258,6 +258,8 @@ Every contribution, no matter how small, means a lot and helps me dedicate more 
 
 This project is an independently maintained fork / derivative project based on [kijai/ComfyUI-WanVideoWrapper](https://github.com/kijai/ComfyUI-WanVideoWrapper) and is released under the **Apache License, Version 2.0**. Thanks again to kijai and the original contributors for their work.
 
-Modified portions and newly added code are Copyright (c) 2026 wuwukasi/wuwukaka. See [NOTICE](NOTICE) for attribution and detailed modification notice requirements. Downstream projects that use or modify the WanAnimatePlus additions should preserve the copyright/modification notices and include a detailed notice in their README, NOTICE file, or equivalent attribution document. That notice should identify the wuwukasi/wuwukaka-derived modules, files, or feature areas and describe any downstream modifications made to those portions.
+Modified portions and newly added source expression by wuwukasi/wuwukaka are Copyright (c) 2026 wuwukasi/wuwukaka. See [NOTICE](NOTICE) for attribution and detailed modification notice requirements. Downstream projects that use or modify the WanAnimatePlus additions should preserve the copyright/modification notices and include a detailed notice in their README, NOTICE file, or equivalent attribution document. That notice should identify the wuwukasi/wuwukaka-derived modules, files, or feature areas and describe any downstream modifications made to those portions.
 
-The wuwukasi/wuwukaka additions include WanAnimatePlus-specific node registration/renaming and integration code, prefix/transition video conditioning, Bernini in-context conditioning, SCAIL-2 embeds support including prefix-mask handling, sampler freeze/prepend integration, loop output tensor caching/background saves, EverAnimate embeds support, sampler/context-window changes, cache/inference safeguards, fast-path attention dispatch propagation, and related custom-op handling.
+The wuwukasi/wuwukaka additions/modifications include WanAnimatePlus-specific node registration/renaming and integration code, prefix/transition video conditioning, Bernini/SCAIL-2/EverAnimate node and sampler integration, context metadata threading, context-window strategy changes, cache-key correctness fixes, cache/inference safeguards, fast-path/cache helper logic, custom-op namespace/registration safeguards, and CustomLinear MXFP8/block-wise `scale_weight` handling.
+
+Scope note: the base Wan model code, original ComfyUI-WanVideoWrapper code, original Alibaba Wan code, ComfyUI/Comfy RoPE implementations, RoPE mathematics/mechanisms themselves, and implementations synced or adapted from upstream projects or third-party PRs are not claimed as original wuwukasi/wuwukaka code. For native quantization, `CustomLinear` MXFP8/block-wise `scale_weight` handling is a WanAnimatePlus modification; upstream PR code remains upstream work. See [NOTICE](NOTICE) for details.

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -72,13 +72,13 @@
 
 通过 `WanAnimatePlus SCAIL_2 Embeds` 提供 SCAIL-2 ref / pose / mask 条件注入。
 
-- 编码 `ref_image`、`pose_images`、`pose_image_mask`、`prefix_mask` 和 `reference_image_mask`
+- 编码 `ref_image`、`pose_images`、`pose_image_mask`、`prefix_frames`、`prefix_mask`、`bg_image` 和 `reference_image_mask`
 - SCAIL-2 输入会在编码前对齐到 32 像素倍数
 - 支持 animation / replacement 两种模式
-- 支持 `prefix_frames` 和 `transition_video` 硬冻结条件
-- SCAIL-2 只有一种 prefix 布局：接入 `prefix_frames` 时前置扩展 37 个像素帧；同时接入 `transition_video` 时 transition 写入第 17-36 帧；只有 `transition_video` 时前置扩展 21 个像素帧
-- `prefix_mask` 会先写入 prefix 对应的像素 mask 帧，再统一编码为 SCAIL-2 mask latent
-- 支持 context window；非首窗口会把 prefix/transition latent prepend 给模型作为上下文，并在 overlap 融合前切掉 prepend 预测
+- 支持单帧 prefix 参考编码和可选的 `transition_video` 硬冻结条件
+- 默认情况下，`prefix_frames` 会作为全分辨率 reference latents 编码，不扩展输出画布；关闭 `single_frame_prefix_encoding` 后才使用 legacy 37 前置像素帧 prefix 布局
+- 单帧 prefix 模式下，`prefix_mask` 走与 `reference_image_mask` 相同的 reference-mask 路径
+- 支持 context window；非首窗口可以看到 prepend 的 prefix/transition 上下文，但这些 prepend 预测不会进入 overlap 融合
 
 ## 安装方式
 
@@ -175,19 +175,24 @@ WanAnimatePlus 暴露了一套完整工作流链路，用于避免与原版 WanV
 | `vae` | 用于编码的 VAE |
 | `width` / `height` / `num_frames` | 目标尺寸；宽高会对齐到 32 像素倍数 |
 | `ref_image` | SCAIL-2 参考图条件 |
+| `bg_image` | animation 模式下可选的单张背景图；单帧模式下会额外编码为 background reference latent，legacy canvas-prefix 模式下追加到用户 `prefix_frames` 之后；replacement 模式下忽略 |
 | `pose_images` | 驱动 pose 视频/图像，按半分辨率编码 |
 | `pose_image_mask` | colored per-identity pose mask 序列 |
-| `prefix_mask` | 可选，与 `prefix_frames` 对齐的 colored mask 图像；按 `1+4+4...` 展开，并在 mask latent 编码前写入 prefix 对应的像素 mask 帧 |
+| `prefix_mask` | 可选，与 `prefix_frames` 对齐的 colored mask 图像；在单帧 prefix 模式下走 reference-mask 路径，在 legacy canvas-prefix 模式下按 `1+4+4...` 展开并写入 prefix 像素 mask 帧 |
 | `reference_image_mask` | colored reference mask 图像 |
 | `replacement_mode` | 启用 SCAIL-2 replacement-mode RoPE 和 reference-mask 合成 |
-| `prefix_frames` | 可选，硬冻结在 latent 序列前部的 prefix 帧 |
+| `preserve_main_ref_background` | 仅 animation 模式使用；开启时保留主参考图背景，关闭时使用 `reference_image_mask` 做黑底 alpha crop。replacement 模式下忽略 |
+| `single_frame_prefix_encoding` | 将 `prefix_frames` 编码为独立的全分辨率 reference latents，而不是扩展画布；默认开启 |
+| `prefix_frames` | 可选 prefix 图像。默认单帧模式下会成为 reference-stream latents；关闭单帧模式后才硬冻结到前置画布 |
 | `transition_video` | 可选，硬冻结在 latent 序列前部的 transition 帧 |
 | `clip_embeds` | 可选，来自 `WanAnimatePlus ClipVisionEncode` 的 CLIP vision 特征 |
 | `force_offload` / `tiled_vae` | VAE 编码相关显存控制 |
 
-短视频生成时 context window 可选；长视频或低显存场景建议使用 context window。context-window 模式下，采样器会把受保护的 prefix/transition latents prepend 给模型作为上下文，并在 overlap 融合前移除这些 prepend 预测。
+短视频生成时 context window 可选；长视频或低显存场景建议使用 context window。context-window 模式下，单帧 prefix reference 会通过 SCAIL-2 reference stream 保持可见；legacy canvas prefix 和 transition latents 会 prepend 给模型作为上下文，并在 overlap 融合前移除这些 prepend 预测。
 
-SCAIL-2 的 `prefix_frames` 固定使用 37 像素帧前置画布。只有 `transition_video` 时使用 21 像素帧前置画布。普通 AnimateEmbeds 里的 45 帧 outfit 布局不适用于 `WanAnimatePlus SCAIL_2 Embeds`。
+SCAIL-2 默认的 `single_frame_prefix_encoding` 模式不会因为 `prefix_frames` 扩展或裁剪输出。如果连接 `transition_video`，前置画布会扩展 21 个像素帧，解码后裁掉这 21 帧。关闭 `single_frame_prefix_encoding` 后，`prefix_frames` 使用 legacy 37 前置像素帧画布；同时连接 `transition_video` 时，transition 帧放在第 17-36 帧。
+
+animation 模式下连接 `bg_image` 时，节点会为该背景图内部添加白色 mask。用户提供的 `prefix_frames` 和 `prefix_mask` 各自最多保留四张，让背景图占用剩余的 reference/prefix 容量。replacement 模式下 `bg_image` 会被忽略。
 
 ## 项目结构
 
@@ -253,6 +258,8 @@ ComfyUI-WanAnimatePlus/
 
 本项目是基于 [kijai/ComfyUI-WanVideoWrapper](https://github.com/kijai/ComfyUI-WanVideoWrapper) 的独立维护 fork / 衍生项目，并按 **Apache License, Version 2.0** 协议发布。再次感谢 kijai 以及原项目贡献者的工作。
 
-本项目中的修改部分和新增代码 Copyright (c) 2026 wuwukasi/wuwukaka。详细归属和修改说明要求见 [NOTICE](NOTICE)。任何使用或修改 WanAnimatePlus 新增部分的下游项目，应保留相关 copyright / modification notices，并在 README、NOTICE 文件或等效归属说明文档中加入详细修改说明。该说明应标明哪些模块、文件或功能区域来自 wuwukasi/wuwukaka，并描述下游对这些部分做了哪些修改。
+本项目中的 wuwukasi/wuwukaka 修改部分和新增源码表达 Copyright (c) 2026 wuwukasi/wuwukaka。详细归属和修改说明要求见 [NOTICE](NOTICE)。任何使用或修改 WanAnimatePlus 新增/修改部分的下游项目，应保留相关 copyright / modification notices，并在 README、NOTICE 文件或等效归属说明文档中加入详细修改说明。该说明应标明哪些模块、文件或功能区域来自 wuwukasi/wuwukaka，并描述下游对这些部分做了哪些修改。
 
-wuwukasi/wuwukaka 新增部分包括 WanAnimatePlus 专用节点注册/重命名和新增功能集成代码、prefix/transition video 条件注入、Bernini in-context conditioning、SCAIL-2 embeds 支持（包括 prefix_mask 处理、freeze/prepend 集成、loop 输出张量缓存/后台保存）、EverAnimate embeds、sampler/context-window 修改、cache/inference 安全保护、fast-path attention dispatch 传递，以及相关 custom-op 处理等。
+wuwukasi/wuwukaka 新增/修改部分包括 WanAnimatePlus 专用节点注册/重命名和新增功能集成代码、prefix/transition video 条件注入、Bernini/SCAIL-2/EverAnimate 节点和采样集成、context metadata threading、context-window 策略修正、cache-key correctness 修复、cache/inference 安全保护、fast-path/cache 辅助逻辑、custom-op namespace/registration safeguards，以及 CustomLinear MXFP8/block-wise `scale_weight` 处理等。
+
+归属范围说明：底层 Wan 模型、ComfyUI-WanVideoWrapper 原始代码、Alibaba Wan 原始代码、ComfyUI/Comfy RoPE 实现、RoPE 数学/机制本身，以及从上游项目或第三方 PR 同步/适配的实现，不作为 wuwukasi/wuwukaka 原创代码主张。native quantization 中，`CustomLinear` MXFP8/block-wise `scale_weight` 处理是 WanAnimatePlus 修改；上游 PR 原始代码仍归属上游。详细说明见 [NOTICE](NOTICE)。

--- a/comfy_quant_linear.py
+++ b/comfy_quant_linear.py
@@ -1,27 +1,38 @@
-# Derived from PR #2029 in this fork's upstream/original project,
-# kijai/ComfyUI-WanVideoWrapper:
+# Includes native quant loading code adapted in part from PR #2029 in this
+# fork's upstream/original project, kijai/ComfyUI-WanVideoWrapper:
 # https://github.com/kijai/ComfyUI-WanVideoWrapper/pull/2029
+# The repository's MXFP8/block-wise scale_weight support predates the PR #2029
+# integration and is a WanAnimatePlus modification.
 #
 # The upstream PR author's copyright remains with that author and the
 # ComfyUI-WanVideoWrapper contributors. Modified portions for WanAnimatePlus
 # integration are Copyright (c) 2026 wuwukasi/wuwukaka.
+# This file does not claim ownership of ComfyUI QuantizedTensor APIs or the
+# upstream PR implementation itself. WanAnimatePlus substantially modified and
+# completed the imported PR code for this fork; MXFP8/block-wise scale_weight,
+# fallback, materialization, and LoRA integration paths are WanAnimatePlus
+# modifications.
 #
 # Modifications in this fork:
 #   - Integrated the loader with the WanAnimatePlus package/module layout.
 #   - Routed WanAnimatePlus CustomLinear quantized layers through direct
 #     forward/LoRA helpers so ComfyUI QuantizedTensor dispatch remains intact.
 #   - Added loader-side guards for LoRA merging and legacy fp8-scaled paths.
+#   - Added MXFP8/block-wise scale_weight handling for the WanAnimatePlus
+#     CustomLinear path.
+#   - Completed/hardened the imported native-quant loading path for this fork's
+#     materialization, fallback, and block-swap behavior.
 #
 # Licensed under the Apache License, Version 2.0.
 
 """Load ComfyUI-native quantized checkpoints in WanAnimatePlus.
 
-ComfyUI native NVFP4/FP8 checkpoints store packed linear weights together with
-``*.comfy_quant`` JSON metadata and scale tensors. Some NVFP4 checkpoints only
-store packed uint8 weights plus scale tensors; this module treats those as native
-quant weights too. It reconstructs weights as ComfyUI ``QuantizedTensor``
-instances so regular ``F.linear`` dispatches to comfy_kitchen kernels through the
-tensor subclass.
+ComfyUI native NVFP4, FP8, and MXFP8 checkpoints store packed linear weights
+together with ``*.comfy_quant`` JSON metadata and scale tensors. Some NVFP4
+checkpoints only store packed uint8 weights plus scale tensors; this module
+treats those as native quant weights too. It reconstructs weights as ComfyUI
+``QuantizedTensor`` instances so regular ``F.linear`` dispatches to
+comfy_kitchen kernels through the tensor subclass.
 """
 
 import json

--- a/custom_linear.py
+++ b/custom_linear.py
@@ -3,10 +3,16 @@
 #   - Renamed custom torch ops from wanvideo::* to wananimateplus::* to avoid collisions.
 #   - Added guarded custom op registration for duplicate imports/stale bytecode.
 #   - Added explicit CUDA implementations for the WanAnimatePlus custom ops.
-#   - Added MXFP8/block-wise scale_weight expansion before linear forward.
-#   - Added ComfyUI native quantized weight passthrough adapted from PR #2029
-#     in this fork's upstream/original project, kijai/ComfyUI-WanVideoWrapper:
+#   - Added MXFP8/block-wise scale_weight expansion before linear forward,
+#     before this fork integrated PR #2029.
+#   - Later integrated ComfyUI native quantized weight passthrough adapted in
+#     part from PR #2029 in this fork's upstream/original project,
+#     kijai/ComfyUI-WanVideoWrapper:
 #     https://github.com/kijai/ComfyUI-WanVideoWrapper/pull/2029
+#     Upstream PR/native-quant logic remains with its original author(s).
+#     WanAnimatePlus changes include the earlier MXFP8/block-wise scale_weight
+#     path plus later completion, fallback, materialization, and LoRA integration
+#     work for this fork.
 # Licensed under the Apache License, Version 2.0
 import torch
 import torch.nn as nn

--- a/nodes.py
+++ b/nodes.py
@@ -8,7 +8,7 @@
 #   - Added WanAnimatePlusEverAnimateEmbeds with anchors, pose/face, bg/mask, pingpong, random/user-first anchors, repeat-anchor padding, and offload controls.
 #   - Added WanAnimatePlusBernini with context_latents/context_roles for source video, reference video, and reference images.
 #   - Added WanAnimatePlusSCAIL2Embeds for wrapper-native SCAIL-2 ref/pose/mask conditioning and prefix/transition freeze latents.
-#   - Adjusted SCAIL-2 bg_image ordering so it is the final reference/prefix input.
+#   - Added SCAIL-2 bg_image reference/prefix composition for animation mode.
 #   - Added Bernini task guidance recommendations and native-aspect reference resizing.
 #   - Added WanAnimatePlus signature widget to the embeds node.
 #   - Added subprocess-isolated SCAIL-2 colormatch to prevent native color_matcher crashes from killing ComfyUI.
@@ -1789,7 +1789,7 @@ class WanAnimatePlusSCAIL2Embeds:
             "optional": {
                 "clip_embeds": ("WANVIDIMAGE_CLIPEMBEDS", {"tooltip": "Clip vision encoded image"}),
                 "ref_image": ("IMAGE", {"tooltip": "Reference image for SCAIL conditioning. If a sequence is connected, only the first frame is used."}),
-                "bg_image": ("IMAGE", {"tooltip": "Optional single background image for animation mode. In single-frame prefix mode it is encoded as the final reference; in legacy prefix mode it is placed after prefix_frames. Ignored in replacement mode."}),
+                "bg_image": ("IMAGE", {"tooltip": "Optional single background image for animation mode. In single-frame prefix mode it is encoded as an extra background reference latent; in legacy prefix mode it is placed after prefix_frames. Ignored in replacement mode."}),
                 "pose_images": ("IMAGE", {"tooltip": "Driving pose video. Encoded at half resolution for SCAIL."}),
                 "prefix_frames": ("IMAGE", {"tooltip": "Optional prefix images. In single-frame prefix mode these are encoded as reference latents; in legacy mode they hard-freeze the beginning of the canvas."}),
                 "prefix_mask": ("IMAGE", {"tooltip": "Optional colored mask images matching prefix_frames. In single-frame prefix mode this follows the reference-mask path; in legacy canvas-prefix mode it is expanded as 1+4+4... and written into the prefix mask frames."}),

--- a/nodes_model_loading.py
+++ b/nodes_model_loading.py
@@ -1,11 +1,15 @@
 # Modified from nodes_model_loading.py in ComfyUI-WanVideoWrapper.
 # Modified portions Copyright (c) 2026 wuwukasi/wuwukaka.
 # This file also includes ComfyUI native quantized loading integration adapted
-# from PR #2029 in this fork's upstream/original project,
+# in part from PR #2029 in this fork's upstream/original project,
 # kijai/ComfyUI-WanVideoWrapper:
 # https://github.com/kijai/ComfyUI-WanVideoWrapper/pull/2029
 # The upstream PR author's copyright remains with that author and the
 # ComfyUI-WanVideoWrapper contributors.
+# WanAnimatePlus modifications here include package integration, loader
+# safeguards, materialization hooks needed by this fork, block-swap/device
+# routing, and MXFP8/block-wise scale_weight handling that predates the PR
+# integration.
 # Licensed under the Apache License, Version 2.0
 import torch
 import torch.nn as nn

--- a/nodes_sampler.py
+++ b/nodes_sampler.py
@@ -4,7 +4,8 @@
 # Modified portions Copyright (c) 2026 wuwukasi/wuwukaka.
 #   - Added APG, APG-chain, and Bernini CFG-chain guidance modes.
 #   - Added sampler graph-detach protection to prevent denoising graph accumulation.
-#   - Added Bernini context_latents/context_roles propagation, RoPE override, window slicing, and simple T2V/Bernini fast-path routing.
+#   - Added Bernini context_latents/context_roles propagation, context-window slicing, and simple T2V/Bernini fast-path routing.
+#   - Threaded upstream/Comfy RoPE selection through added Bernini/SCAIL context paths, including local context-window starts.
 #   - Added prefix frame support in context windows, looping, face/pose slices, image conditions, and noise predictions.
 #   - Added transition_video hard conditioning and canvas_expansion_px-aware Uni3C/render/output handling.
 #   - Added EverAnimate segmented sampling with anchors, generated/random/user-first anchors, repeat-anchor padding, bg/mask conditioning, motion latents, and internal context-option blocking.
@@ -13,6 +14,7 @@
 #   - Added SCAIL-2 sampler-side freeze_mask handling for prefix/transition latents.
 #   - Added SCAIL-2 loop output tensor caching, background cache saves, and tail-frame anchor encoding.
 #   - Added subprocess-isolated SCAIL-2 colormatch to prevent native color_matcher crashes from killing ComfyUI.
+#   RoPE math/mechanisms and Comfy RoPE implementations remain upstream/third-party work.
 # Licensed under the Apache License, Version 2.0
 import os, gc, math, copy, shutil
 import torch

--- a/wanvideo/modules/model.py
+++ b/wanvideo/modules/model.py
@@ -2,13 +2,14 @@
 # Modified from wanvideo/modules/model.py in ComfyUI-WanVideoWrapper.
 # Modified portions Copyright (c) 2026 wuwukasi/wuwukaka.
 #   - Added Bernini in-context latent tokens with patch-size padding.
-#   - Added Bernini source_id RoPE rotation matrix helper and context RoPE segments.
-#   - Added context window start/context shape entries to Comfy RoPE generation and cache keys.
+#   - Integrated upstream/Comfy RoPE handling with added Bernini/SCAIL context paths.
+#   - Added context-window metadata threading, local-start handling, and cache-key fixes.
 #   - Added variable WanAnimate anchor count support for pose and face embedding offsets.
 #   - Added a streamlined simple T2V/Bernini fast path with block-swap prefetch support.
 #   - Added simple T2V text/time embedding caches, cache-key helpers, and guarded no-op device moves.
 #   - Added a streamlined SCAIL-2 CFG fast path for the local WanAnimatePlus sampler.
 #   - Added main-path cross-attention attention-mode propagation and target-fusion dispatch fixes.
+#   RoPE math/mechanisms and Comfy RoPE implementations remain upstream/third-party work.
 # Licensed under the Apache License, Version 2.0
 import math
 import torch


### PR DESCRIPTION
## Summary
- Clarify README/NOTICE attribution scope for WanAnimatePlus modified source expression.
- Keep upstream/third-party code, RoPE mechanisms, and upstream PR code out of original-authorship claims.
- Mark CustomLinear MXFP8/block-wise scale_weight handling as a WanAnimatePlus modification and keep detailed native-quant attribution in NOTICE/source headers.

## Verification
- git diff --cached --check before commit